### PR TITLE
EffortControl GiveReward method implemented Null Check. Escape during…

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/InitScreen_Level.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/InitScreen_Level.cs
@@ -92,6 +92,9 @@ public class InitScreen_Level : ControlLevel
         {
             if (StartPanel_GO.transform.localPosition != Vector3.zero)
                 StartPanel_GO.transform.localPosition = Vector3.MoveTowards(StartPanel_GO.transform.localPosition, Vector3.zero, 900 * Time.deltaTime);
+
+            if (InputBroker.GetKeyUp(KeyCode.Escape))
+                Application.Quit();
         });
         StartScreen.SpecifyTermination(() => ConfirmButtonPressed, CollectInfo, () =>
         {
@@ -116,6 +119,9 @@ public class InitScreen_Level : ControlLevel
                 if (ErrorHandled())
                     ErrorHandling_GO.SetActive(false);
             }
+
+            if (InputBroker.GetKeyUp(KeyCode.Escape))
+                Application.Quit();
         });
         CollectInfo.SpecifyTermination(() => ConfirmButtonPressed, () => null, () =>
         {
@@ -158,7 +164,7 @@ public class InitScreen_Level : ControlLevel
                 panel.SetActive(true);
         }
         
-
+        //Config Toggles:
         if(LocalConfig_Toggle.isOn)
         {
             LocalConfig_GO.SetActive(true);
@@ -172,6 +178,7 @@ public class InitScreen_Level : ControlLevel
                 GreyOutPanels_Array[2].SetActive(true); //set config folder grey out panel active since they havent connected to server yet
         }
 
+        //Data Toggles:
         if (LocalData_Toggle.isOn)
         {
             LocalData_GO.SetActive(true);
@@ -222,7 +229,7 @@ public class InitScreen_Level : ControlLevel
                     return true;
                 break;
             default:
-                Debug.LogError("DEFAULT ERROR HANDLED SWITCH STATEMENT!");
+                Debug.LogWarning("DEFAULT ERROR HANDLED SWITCH STATEMENT!");
                 break;
         }
         return false;
@@ -261,7 +268,7 @@ public class InitScreen_Level : ControlLevel
             SessionValues.ConfigFolderPath = Application.persistentDataPath + Path.DirectorySeparatorChar + "M_USE_DefaultConfigs";
         }
         else
-            Debug.LogError("TRYING TO SET CONFIG INFO BUT NO CONFIG TOGGLE IS SELECTED!");
+            Debug.LogWarning("TRYING TO SET CONFIG INFO BUT NO CONFIG TOGGLE IS SELECTED!");
     }
 
     private void HandleConfigToggle(GameObject selectedGO)
@@ -440,7 +447,7 @@ public class InitScreen_Level : ControlLevel
             ServerData_GO.SetActive(false);
             ServerConfig_GO.SetActive(false);
 
-            //Block out local toggle options if web build:
+            //Un-Block out local toggle options if not web build:
             GameObject.Find("LocalConfigsToggle_GREYPANEL").SetActive(false);
             GameObject.Find("LocalDataToggle_GREYPANEL").SetActive(false);
         }
@@ -523,7 +530,7 @@ public class InitScreen_Level : ControlLevel
             }
             else
             {
-                Debug.Log("UNABLE TO CONNECT TO SERVER!");
+                Debug.LogWarning("UNABLE TO CONNECT TO SERVER!");
                 PlayAudio(Error_AudioClip);
                 ConnectToServerButton_GO.GetComponentInChildren<Image>().color = Color.red;
                 RedX_GO.SetActive(true);

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_States.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_States.cs
@@ -712,10 +712,7 @@ namespace USE_States
 		public bool Paused = true;
 
 		public abstract void DefineControlLevel();
-		public virtual void LoadSettings()
-		{
 
-		}
 
 		public void InitializeControlLevel()
 		{
@@ -736,7 +733,6 @@ namespace USE_States
 			Duration = -1;
 			controlLevelTerminationSpecifications = new List<ControlLevelTerminationSpecification>();
 
-            LoadSettings();
             if (CallDefineLevelAutomatically)
                 DefineControlLevel();
 

--- a/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_Namespace.cs
+++ b/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_Namespace.cs
@@ -11,7 +11,6 @@ namespace EffortControl_Namespace
 
     public class EffortControl_BlockDef : BlockDef
     {
-        public bool TokensInMiddleOfOutlines;
         public int NumClicksLeft;
         public int NumClicksRight;
         public int NumCoinsLeft;
@@ -21,6 +20,8 @@ namespace EffortControl_Namespace
         public int PulseSizeLeft;
         public int PulseSizeRight;
         public int ClicksPerOutline;
+        public bool TokensInMiddleOfOutlines;
+
         public override void GenerateTrialDefsFromBlockDef()
         {
             TrialDefs = new List<EffortControl_TrialDef>().ConvertAll(x => (TrialDef)x);
@@ -41,14 +42,12 @@ namespace EffortControl_Namespace
                 td.PulseSizeRight = PulseSizeRight;
                 td.ClicksPerOutline = ClicksPerOutline;
                 TrialDefs.Add(td);
-
             }
         }
     }
 
     public class EffortControl_TrialDef : TrialDef
     {
-        public bool TokensInMiddleOfOutlines;
         public int NumClicksLeft;
         public int NumClicksRight;
         public int NumCoinsLeft;
@@ -58,6 +57,7 @@ namespace EffortControl_Namespace
         public int PulseSizeLeft;
         public int PulseSizeRight;
         public int ClicksPerOutline;
+        public bool TokensInMiddleOfOutlines;
     }
 
     public class EffortControl_StimDef : StimDef

--- a/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TrialLevel.cs
@@ -517,12 +517,7 @@ public class EffortControl_TrialLevel : ControlLevel_Trial_Template
         Feedback.AddUniversalTerminationMethod(() =>
         {
             if(TokenFBController.IsTokenBarFull())
-            {
-                if(SessionValues.SyncBoxController != null)
-                    GiveReward();
-
-            }
-            
+                GiveReward();
             TokenFBController.enabled = false;
             AddTokenInflateAudioPlayed = false;
         });
@@ -754,6 +749,9 @@ public class EffortControl_TrialLevel : ControlLevel_Trial_Template
 
     void GiveReward()
     {
+        if (SessionValues.SyncBoxController == null)
+            return;
+
         if (SideChoice == "Left")
         {
             SessionValues.SyncBoxController.SendRewardPulses(CurrentTrial.NumPulsesLeft, CurrentTrial.PulseSizeLeft);


### PR DESCRIPTION
… Init Screen.

1) Moved the null check for Effort Control's GiveReward() method from the call to the method itself. Removed unused LoadSettings() method from USE_States. 3) Added ability for user to Escape a build during init screen.