### PR TITLE
Fixed MazeGame Tile AddToStimGroup Warning

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
@@ -214,8 +214,7 @@ namespace USE_StimulusManagement
 			}
 			else
 			{
-				Debug.LogWarning("Attempted to add stim " + StimName + " to StimGroup " +
-				                 sg.stimGroupName + " but this stimulus is already a member of this StimGroup.");
+				Debug.LogWarning("Attempted to add stim " + StimName + " to StimGroup " + sg.stimGroupName + " but this stimulus is already a member of this StimGroup.");
 			}
 		}
 

--- a/USE_CORE/Assets/_USE_Tasks/MazeGame/MazeGame_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/MazeGame/MazeGame_TrialLevel.cs
@@ -505,7 +505,6 @@ public class MazeGame_TrialLevel : ControlLevel_Trial_Template
 
         tiles = new StimGroup("Tiles");
 
-        
         for (var x = 1; x <= mazeDims.x; x++)
         for (var y = 1; y <= mazeDims.y; y++)
         {
@@ -548,10 +547,7 @@ public class MazeGame_TrialLevel : ControlLevel_Trial_Template
             else if (!CurrentTrialDef.DarkenNonPathTiles || CurrentTaskLevel.currMaze.mPath.Contains((chessCoordName)))
                 tileStimDef.StimGameObject.GetComponent<Tile>().setColor(tile.DEFAULT_TILE_COLOR);
             else
-                tileStimDef.StimGameObject.GetComponent<Tile>().setColor(new Color(0.5f, 0.5f, 0.5f));
-            
-            tiles.AddStims(tileStimDef);
-            
+                tileStimDef.StimGameObject.GetComponent<Tile>().setColor(new Color(0.5f, 0.5f, 0.5f));            
         }
         mazeLoaded = true;
         //Make sure to reset the maze to start at the start tile


### PR DESCRIPTION
Fixed the MazeGame's AddToStimGroup warning by removing the duplicate tiles.AddStims(tileStimDef) code.