### PR TITLE
MaxStimLoadingDuration variable update

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
@@ -337,7 +337,7 @@ namespace USE_StimulusManagement
 			yield return new WaitUntil(() => (StimGameObject != null && !LoadingAsync) || Time.time - startTime >= SessionValues.SessionDef.MaxStimLoadingDuration);
 
 			if (StimGameObject == null)
-				Debug.LogError("STIM GO STILL NULL AFTER YIELDING! MAX STIM LOADING DURATION MUST HAVE SURPASSED!");
+				Debug.LogError("STIM GO STILL NULL AFTER YIELDING! MAX STIM LOADING DURATION HAS BEEN SURPASSED!");
 
 			//For 2D stim, set as child of Canvas:
             if (SessionValues.Using2DStim && CanvasGameObject != null)

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_Def_Namespace.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_Def_Namespace.cs
@@ -252,9 +252,17 @@ namespace USE_Def_Namespace
         public int Camera_TrialPulseMinGap_Sec = 8;
 
         /// <summary>
+        /// Private backing field used to allow MaxStimLoadingDuration to have default value of 2, but also never be less than 1
+        /// </summary>
+        private float maxStimLoadingDuration = 2f;
+        /// <summary>
         /// Max amount of time for Stim to be loaded.
         /// </summary>
-        public float MaxStimLoadingDuration = 2f;
+        public float MaxStimLoadingDuration
+        {
+            get { return maxStimLoadingDuration; }
+            set { maxStimLoadingDuration = MathF.Max(value, 1f); }
+        }
 
     }
 


### PR DESCRIPTION
Updated the MaxStimLoadingDuration variable to have a private backing variable to ensure it both has a default value of 2 and also is never below 1.