### PR TITLE
Disabled main task backgrounds at template level

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Session.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Session.cs
@@ -56,8 +56,6 @@ namespace USE_ExperimentTemplate_Session
 {
     public class ControlLevel_Session_Template : ControlLevel
     {
-        [HideInInspector] public int SessionId_SQL;
-
         [HideInInspector] public bool TasksFinished;
         
         protected SummaryData SummaryData;
@@ -629,7 +627,7 @@ namespace USE_ExperimentTemplate_Session
                 //SessionCam.gameObject.SetActive(false);
                 CurrentTask.TaskCam = GameObject.Find(CurrentTask.TaskName + "_Camera").GetComponent<Camera>();
 
-                SetTasksMainBackground(); 
+                SetTaskMainBackground(); 
 
                 if (CameraMirrorTexture != null)
                     CameraMirrorTexture.Release();
@@ -789,7 +787,7 @@ namespace USE_ExperimentTemplate_Session
         }
 
         //Method is used to have every task set their main background as the MUSE blue background
-        private void SetTasksMainBackground()
+        private void SetTaskMainBackground()
         {
             if (CurrentTask.TaskCam != null)
             {

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
@@ -274,6 +274,10 @@ namespace USE_ExperimentTemplate_Trial
                     SessionValues.HumanStartPanel.AdjustPanelBasedOnTrialNum(TrialCount_InTask, TrialCount_InBlock);
 
                 AddToStimLists(); //Seems to work here instead of each task having to call it themselves from InitTrial.
+
+                //Disable the Task's MUSE Background that's set in Session Level's SetTasksMainBackground() method:
+                DisableTaskMainBackground();
+
             });
 
             FinishTrial.AddSpecificInitializationMethod(() =>
@@ -374,6 +378,14 @@ namespace USE_ExperimentTemplate_Trial
 
         }
 
+        private void DisableTaskMainBackground()
+        {
+            if (TaskLevel.TaskCam != null)
+            {
+                if (TaskLevel.TaskCam.gameObject.TryGetComponent<Skybox>(out var skyboxComponent))
+                    skyboxComponent.enabled = false;
+            }
+        }
 
         private IEnumerator HandleLoadingStims()
         {

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/StimulusHandling/USE_StimulusManagement.cs
@@ -358,6 +358,7 @@ namespace USE_StimulusManagement
 			{
 				string fullPath = $"{SessionValues.DefaultStimFolderPath}/{FileName}";
 				StimGameObject = Object.Instantiate(Resources.Load(fullPath) as GameObject);
+				StimGameObject.SetActive(false);
 			}
 			catch(Exception e)
 			{

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_States.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_States.cs
@@ -1208,19 +1208,23 @@ namespace USE_States
 
         public static Material CreateSkybox(Texture2D tex)
         {
-			if (tex == null)
-				Debug.LogWarning("TEX IS NULL WHEN TRYING TO CREATE SKYBOX!");
+			try
+			{
+				Material materialSkybox = new Material(Shader.Find("Skybox/6 Sided"));
+				materialSkybox.SetTexture("_FrontTex", tex);
+				materialSkybox.SetTexture("_BackTex", tex);
+				materialSkybox.SetTexture("_LeftTex", tex);
+				materialSkybox.SetTexture("_RightTex", tex);
+				materialSkybox.SetTexture("_UpTex", tex);
+				materialSkybox.SetTexture("_DownTex", tex);
+				return materialSkybox;
+			}
+			catch(Exception e)
+			{
+				Debug.LogWarning("FAILED TO CREATE SKYBOX! Error: " + e.Message.ToString());
+				return null;
+			}
 
-			Material materialSkybox = new Material(Shader.Find("Skybox/6 Sided"));
-
-			materialSkybox.SetTexture("_FrontTex", tex);
-            materialSkybox.SetTexture("_BackTex", tex);
-            materialSkybox.SetTexture("_LeftTex", tex);
-            materialSkybox.SetTexture("_RightTex", tex);
-            materialSkybox.SetTexture("_UpTex", tex);
-            materialSkybox.SetTexture("_DownTex", tex);
-
-            return materialSkybox;
         }
 
         public GameObject FindInactiveGameObjectByName(string name)

--- a/USE_CORE/Assets/_USE_Tasks/ContinuousRecognition/ContinuousRecognition_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/ContinuousRecognition/ContinuousRecognition_TrialLevel.cs
@@ -190,8 +190,6 @@ public class ContinuousRecognition_TrialLevel : ControlLevel_Trial_Template
         //INIT Trial state -------------------------------------------------------------------------------------------------------
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             if (TrialCount_InBlock == 0)
                 CalculateBlockFeedbackLocations();
 

--- a/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TaskLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TaskLevel.cs
@@ -65,9 +65,9 @@ public class EffortControl_TaskLevel : ControlLevel_Task_Template
 
         RunBlock.AddSpecificInitializationMethod(() =>
         {
-            trialLevel.ResetBlockVariables();
             CurrentBlock.ContextName = CurrentBlock.ContextName.Trim();
             SetSkyBox(CurrentBlock.ContextName);
+            trialLevel.ResetBlockVariables();
         });
 
         BlockFeedback.AddSpecificInitializationMethod(() => HandleBlockStrings());

--- a/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/EffortControl/EffortControl_TrialLevel.cs
@@ -191,8 +191,6 @@ public class EffortControl_TrialLevel : ControlLevel_Trial_Template
         //INIT Trial state ----------------------------------------------------------------------------------------------------------------------------------------------
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             //Set handler active in case they ran out of time mid inflation and it was never set back to active
             if (Handler != null)
                 Handler.HandlerActive = true;

--- a/USE_CORE/Assets/_USE_Tasks/FlexLearning/FlexLearning_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/FlexLearning/FlexLearning_TrialLevel.cs
@@ -156,8 +156,6 @@ public class FlexLearning_TrialLevel : ControlLevel_Trial_Template
         TouchFBController.EnableTouchFeedback(ShotgunHandler, currentTaskDef.TouchFeedbackDuration, currentTaskDef.StartButtonScale *10, FL_CanvasGO);
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             if (SessionValues.SessionDef.MacMainDisplayBuild & !Application.isEditor) //adj text positions if running build with mac as main display
                 TokenFBController.AdjustTokenBarSizing(200);
 

--- a/USE_CORE/Assets/_USE_Tasks/MazeGame/MazeGame_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/MazeGame/MazeGame_TrialLevel.cs
@@ -200,8 +200,6 @@ public class MazeGame_TrialLevel : ControlLevel_Trial_Template
 
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             SelectionHandler.HandlerActive = true;
             if (SelectionHandler.AllSelections.Count > 0)
                 SelectionHandler.ClearSelections();

--- a/USE_CORE/Assets/_USE_Tasks/VisualSearch/VisualSearch_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/VisualSearch/VisualSearch_TrialLevel.cs
@@ -151,8 +151,6 @@ public class VisualSearch_TrialLevel : ControlLevel_Trial_Template
 
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             if (SessionValues.SessionDef.MacMainDisplayBuild & !Application.isEditor) //adj text positions if running build with mac as main display
                 TokenFBController.AdjustTokenBarSizing(200);
 

--- a/USE_CORE/Assets/_USE_Tasks/WhatWhenWhere/WhatWhenWhere_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/WhatWhenWhere/WhatWhenWhere_TrialLevel.cs
@@ -192,12 +192,7 @@ public class WhatWhenWhere_TrialLevel : ControlLevel_Trial_Template
 
         TouchFBController.EnableTouchFeedback(ShotgunHandler, currentTaskDef.TouchFeedbackDuration, currentTaskDef.StartButtonScale * 10, WWW_CanvasGO);
 
-        InitTrial.AddSpecificInitializationMethod(() =>
-        {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
-            InitializeShotgunHandler();
-        });
+        InitTrial.AddSpecificInitializationMethod(() => InitializeShotgunHandler());
         InitTrial.SpecifyTermination(() => ShotgunHandler.LastSuccessfulSelectionMatchesStartButton(), Delay, ()=>
         {
             CalculateSliderSteps();

--- a/USE_CORE/Assets/_USE_Tasks/WorkingMemory/WorkingMemory_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/WorkingMemory/WorkingMemory_TrialLevel.cs
@@ -151,8 +151,6 @@ public class WorkingMemory_TrialLevel : ControlLevel_Trial_Template
 
         InitTrial.AddSpecificInitializationMethod(() =>
         {
-            Camera.main.gameObject.GetComponent<Skybox>().enabled = false; //Disable cam's skybox so the RenderSettings.Skybox can show the Context background
-
             if (SessionValues.WebBuild)
                 TokenFBController.AdjustTokenBarSizing(110);
 


### PR DESCRIPTION
Moved individual task's disabling of main skybox to trial template. Now every task starts with the main muse background and its disabled at end of SetupTrial.