### PR TITLE
Fixed SA TouchFeedback location and am unsubscribing from Events on d…

### DIFF
--- a/USE_CORE/Assets/_USE_Tasks/SustainedAttention/SustainedAttention_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/SustainedAttention/SustainedAttention_TrialLevel.cs
@@ -96,7 +96,7 @@ public class SustainedAttention_TrialLevel : ControlLevel_Trial_Template
         SetupTrial.SpecifyTermination(() => true, InitTrial);
 
         var Handler = Session.SelectionTracker.SetupSelectionHandler("trial", "MouseButton0Click", Session.MouseTracker, InitTrial, Play); //Setup Handler
-        TouchFBController.EnableTouchFeedback(Handler, CurrentTask.TouchFeedbackDuration, CurrentTask.StartButtonScale * 30, SustainedAttention_CanvasGO, true); //Enable Touch Feedback
+        TouchFBController.EnableTouchFeedback(Handler, CurrentTask.TouchFeedbackDuration, CurrentTask.StartButtonScale * 15, SustainedAttention_CanvasGO, false); //Enable Touch Feedback
 
         //InitTrial state ----------------------------------------------------------------------------------------------------------------------------------------------
         InitTrial.AddSpecificInitializationMethod(() =>
@@ -141,12 +141,10 @@ public class SustainedAttention_TrialLevel : ControlLevel_Trial_Template
         Play.AddSpecificInitializationMethod(() =>
         {
             GiveRewardIfSliderFull = false;
-
             if (Handler.AllSelections.Count > 0)
                 Handler.ClearSelections();
 
             AudioFBController.Play("EC_BalloonChosen");
-
             ObjectManager.ActivateObjectMovement();
         });
         Play.AddUpdateMethod(() =>
@@ -225,6 +223,16 @@ public class SustainedAttention_TrialLevel : ControlLevel_Trial_Template
 
         DefineTrialData();
         DefineFrameData();
+    }
+
+    private void OnDestroy()
+    {
+        if(ObjectManager != null)
+        {
+            ObjectManager.OnTargetIntervalMissed += TargetIntervalMissed; //UNsubscribe to MissedInterval Event
+            ObjectManager.OnDistractorAvoided += DistractorAvoided; //UNsubscribe to DistractorAvoided Event
+        }
+
     }
 
     private void TargetIntervalMissed()


### PR DESCRIPTION
…estroy

Fixed the location of the touch feedback for Sustained Attention and also am now unsubscribing from the Object Manager's events when the trial level is destroyed.