### PR TITLE
AS Blockname Fix

### DIFF
--- a/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TaskLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TaskLevel.cs
@@ -80,7 +80,7 @@ public class AntiSaccade_TaskLevel : ControlLevel_Task_Template
     {
         string[] splitArray = CurrentBlock.BlockName.Split('.');
 
-        if (splitArray.Length < 1)
+        if (splitArray.Length < 2)
             return;
 
         string split = splitArray[1].ToLower();


### PR DESCRIPTION
Fixed the AddToThresholdCategory method to ensure it doesnt throw an error when the block name doesnt contain a period.