### PR TITLE
TokenBar Data Fix

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
@@ -214,10 +214,12 @@ namespace USE_ExperimentTemplate_Trial
 
             Debugger = new UI_Debugger();
 
+            SubscribeToEvents();
+
             //DefineTrial();
+
             Add_ControlLevel_InitializationMethod(() =>
             {
-                SubscribeToEvents();
 
                 TrialCount_InBlock = -1;
                 DefineCustomTrialDefSelection();

--- a/USE_CORE/Assets/_USE_Tasks/AudioVisual/AudioVisual_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/AudioVisual/AudioVisual_TrialLevel.cs
@@ -373,8 +373,6 @@ public class AudioVisual_TrialLevel : ControlLevel_Trial_Template
 
     public override void OnTokenBarFull()
     {
-        Debug.LogWarning("TOKEN BAR FULL!");
-
         NumTbCompletions_Block++;
         CurrentTaskLevel.TokenBarCompletions_Task++;
 


### PR DESCRIPTION
Fixed the incorrect TokenBar Completions data. The SubscribeToEvents() method was being called during the initialization of each trial level but should only be called once.