### PR TITLE
AntiSaccade tokenbar variables block level fix.

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Trial.cs
@@ -207,6 +207,7 @@ namespace USE_ExperimentTemplate_Trial
             Delay.AddTimer(() => DelayDuration, () => StateAfterDelay);
 
             Cursor.visible = false;
+
             if (TokenFBController != null)
                 TokenFBController.enabled = false;
 

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
@@ -410,7 +410,6 @@ namespace SelectionTracking
                 if (OngoingSelection != null)
                 {
                     OngoingSelection.ErrorType = error;
-                    Debug.LogWarning("ERROR: " + error);
                     TouchErrorFeedback?.Invoke(this, new TouchFBController.TouchFeedbackArgs(OngoingSelection));
                 }
                 else

--- a/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TaskLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TaskLevel.cs
@@ -65,8 +65,8 @@ public class AntiSaccade_TaskLevel : ControlLevel_Task_Template
         {
             trialLevel.ResetBlockVariables();
 
-            trialLevel.TokenFBController.SetTokenBarValue(trialLevel.CurrentTrial.NumInitialTokens);
-
+            trialLevel.TokenFBController.SetTotalTokensNum(CurrentBlock.TokenBarCapacity);
+            trialLevel.TokenFBController.SetTokenBarValue(CurrentBlock.NumInitialTokens);
 
             CurrentBlock.ContextName = CurrentBlock.ContextName.Trim();
             SetSkyBox(CurrentBlock.ContextName);

--- a/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/AntiSaccade/AntiSaccade_TrialLevel.cs
@@ -119,7 +119,6 @@ public class AntiSaccade_TrialLevel : ControlLevel_Trial_Template
         {
             TokenFBController.enabled = false;
             LoadConfigUIVariables();
-            TokenFBController.SetTotalTokensNum(CurrentTrial.TokenBarCapacity);
 
             SetDataStrings();
             
@@ -350,9 +349,14 @@ public class AntiSaccade_TrialLevel : ControlLevel_Trial_Template
         CurrentTaskLevel.NumRewardPulses_InBlock += CurrentTrial.NumPulses;
         CurrentTaskLevel.NumRewardPulses_InTask += CurrentTrial.NumPulses;
 
-        //Reset tokenbar to numInitialTokens
-        TokenFBController.SetTokenBarValue(CurrentTrial.NumInitialTokens);
+        StartCoroutine(ResetTbAfterFilled());
 
+    }
+
+    private IEnumerator ResetTbAfterFilled()
+    {
+        yield return new WaitForSeconds(1.5f); //reset tb after waiting a second
+        TokenFBController.SetTokenBarValue(CurrentTaskLevel.currentBlockDef.NumInitialTokens);
     }
 
     private void MakeStimFaceCamera(StimGroup stims)


### PR DESCRIPTION
Moved NumInitialTokens and TokenBarCapacity to the block level and have it reset after they fill it. Also fixed missing tokenbar bug.