### PR TITLE
Added SpoofGazeWithMouse and GC RewardStructure

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/SetupSession_Level.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/SetupSession_Level.cs
@@ -221,6 +221,12 @@ public class SetupSession_Level : ControlLevel
             Session.GazeTracker.enabled = true;
             Session.SessionLevel.SelectionHandler.MinDuration = 0.7f;
         }
+        else if(Session.SessionDef.SelectionType.ToLower().Equals("mouseHover"))
+        {
+            Session.SessionLevel.SelectionHandler = Session.SelectionTracker.SetupSelectionHandler("session", "MouseHover", Session.MouseTracker, inputActive, inputInactive);
+            Session.MouseTracker.enabled = true;
+            Session.SessionLevel.SelectionHandler.MinDuration = 0.7f;
+        }
         else
         {
             Session.SessionLevel.SelectionHandler = Session.SelectionTracker.SetupSelectionHandler("session", "MouseButton0Click", Session.MouseTracker, inputActive, inputInactive);

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Session.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Hierarchical Finite State Machine/USE_ExperimentTemplate_Session.cs
@@ -252,7 +252,7 @@ namespace USE_ExperimentTemplate_Session
 
                 StartCoroutine(FrameData.CreateFile());
 
-                if (Session.SessionDef.EyeTrackerActive)
+                if (Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.CreateFile());
                 
 
@@ -320,13 +320,6 @@ namespace USE_ExperimentTemplate_Session
             gazeCalibration.AddSpecificInitializationMethod(() =>
             {
 
-                // Deactivate TaskSelection scene elements
-                /*Session.InitCamGO.SetActive(false);
-                SessionCam.gameObject.SetActive(true);
-
-                MainDirectionalLight.SetActive(true);
-                Session.TaskSelectionCanvasGO.SetActive(true);*/
-
                 if (Session.WebBuild)
                 {
                     Session.MainExperimenterCanvas_GO.SetActive(false);
@@ -366,7 +359,6 @@ namespace USE_ExperimentTemplate_Session
                 // Set the current task and trial levels 
                 Session.TaskLevel = Session.GazeCalibrationController.GazeCalibrationTaskLevel;
                 Session.TrialLevel = Session.GazeCalibrationController.GazeCalibrationTrialLevel;
-
             });
 
             gazeCalibration.AddLateUpdateMethod(() =>
@@ -375,7 +367,7 @@ namespace USE_ExperimentTemplate_Session
 
                 Session.SelectionTracker.UpdateActiveSelections();
                 AppendSerialData();
-                if (Session.SessionDef.EyeTrackerActive)
+                if (Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.AppendDataToBuffer());
 
                 //Session.EventCodeManager.EventCodeLateUpdate();
@@ -386,29 +378,13 @@ namespace USE_ExperimentTemplate_Session
             {
                 Session.GazeCalibrationController.WriteSerialAndGazeDataThenReassignDataPath("GazeCalibrationToSession");
 
-                /* if (Session.SessionDef.SerialPortActive)
-                 {
-                     StartCoroutine(Session.SerialRecvData.AppendDataToFile());
-                     StartCoroutine(Session.SerialSentData.AppendDataToFile());
-                 }
-
-                 if (Session.SessionDef.EyeTrackerActive)
-                     StartCoroutine(Session.GazeData.AppendDataToFile());
-
-
-                 // Reset level and task references
-                 Session.GazeData.folderPath = Session.TaskSelectionDataPath;
-                 Session.SerialRecvData.folderPath = Session.TaskSelectionDataPath;
-                 Session.SerialSentData.folderPath = Session.TaskSelectionDataPath;*/
-
-/*                StartCoroutine(SummaryData.AddTaskRunData(Session.TaskLevel.ConfigFolderName, Session.TaskLevel, Session.TaskLevel.GetTaskSummaryData()));
-*/
                 StartCoroutine(SessionData.AppendDataToBuffer());
                 StartCoroutine(SessionData.AppendDataToFile());
                 
 
+                
                 // Check and exit calibration mode for Tobii eye tracker
-                if (Session.TobiiEyeTrackerController.isCalibrating)
+                if (!Session.SessionDef.SpoofGazeWithMouse && Session.TobiiEyeTrackerController.isCalibrating)
                 {
                     Session.TobiiEyeTrackerController.isCalibrating = false;
                     Session.TobiiEyeTrackerController.ScreenBasedCalibration.LeaveCalibrationMode();
@@ -716,7 +692,7 @@ namespace USE_ExperimentTemplate_Session
 
                 AppendSerialData();
                 StartCoroutine(FrameData.AppendDataToBuffer());
-                if(Session.SessionDef.EyeTrackerActive)
+                if(Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.AppendDataToBuffer());
 
             });
@@ -798,7 +774,7 @@ namespace USE_ExperimentTemplate_Session
                 Session.SelectionTracker.UpdateActiveSelections();
                 AppendSerialData();
                 StartCoroutine(FrameData.AppendDataToBuffer());
-                if(Session.SessionDef.EyeTrackerActive)
+                if(Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.AppendDataToBuffer());
             });
 
@@ -833,7 +809,7 @@ namespace USE_ExperimentTemplate_Session
                 Session.SelectionTracker.UpdateActiveSelections();
                 AppendSerialData();
                 
-                if (Session.SessionDef.EyeTrackerActive)
+                if (Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.AppendDataToBuffer());
 
                 if (CurrentTask.FrameData != null)
@@ -874,7 +850,7 @@ namespace USE_ExperimentTemplate_Session
 
                 Session.SelectionTracker.UpdateActiveSelections();
                 AppendSerialData();
-                if(Session.SessionDef.EyeTrackerActive)
+                if(Session.SessionDef.EyeTrackerActive && !Session.SessionDef.SpoofGazeWithMouse)
                     StartCoroutine(Session.GazeData.AppendDataToBuffer());
             });
 
@@ -1308,11 +1284,14 @@ namespace USE_ExperimentTemplate_Session
         {
             if (GameObject.Find("TobiiEyeTrackerController") == null)
             {
+                if(!Session.SessionDef.SpoofGazeWithMouse){
                 // gets called once when finding and creating the tobii eye tracker prefabs
                 GameObject TobiiEyeTrackerControllerGO = new GameObject("TobiiEyeTrackerController");
                 Session.TobiiEyeTrackerController = TobiiEyeTrackerControllerGO.AddComponent<TobiiEyeTrackerController>();
                 Session.TobiiEyeTrackerController.EyeTracker_GO = Instantiate(Resources.Load<GameObject>("EyeTracker"), TobiiEyeTrackerControllerGO.transform);
                 Session.TobiiEyeTrackerController.TrackBoxGuide_GO = Instantiate(Resources.Load<GameObject>("TrackBoxGuide"), TobiiEyeTrackerControllerGO.transform);
+                }
+
                 Session.GazeCalibrationController = Instantiate(Resources.Load<GameObject>("GazeCalibration")).GetComponent<GazeCalibrationController>();
                // THIS LINE BELOW CONTROLS THE OVERLAYING GAZE ONTO THE PLAYER SCENE
                // Session.TobiiEyeTrackerController.GazeTrail_GO = Instantiate(Resources.Load<GameObject>("GazeTrail"), TobiiEyeTrackerControllerGO.transform);

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
@@ -172,6 +172,8 @@ namespace SelectionTracking
 
             gazeSelection.TerminationErrorTriggers.Add("DurationTooShort", gazeSelection.DefaultConditions("DurationTooShort"));
             gazeSelection.CurrentInputLocation = () => InputBroker.gazePosition;
+            gazeSelection.MaxPixelDisplacement = 70;
+            gazeSelection.MinDuration = 0.7f;
             DefaultSelectionHandlers.Add("GazeSelection", gazeSelection);
 
             //----------------------------------------GAZE SHOTGUN HANDLER: --------------------------------------------------
@@ -189,6 +191,8 @@ namespace SelectionTracking
             gazeShotgun.TerminationErrorTriggers.Add("DurationTooShort", gazeShotgun.DefaultConditions("DurationTooShort"));
 
             gazeShotgun.CurrentInputLocation = () => InputBroker.gazePosition;
+            gazeShotgun.MaxPixelDisplacement = 70;
+            gazeShotgun.MinDuration = 0.7f;
             DefaultSelectionHandlers.Add("GazeShotgun", gazeShotgun);
             
             
@@ -566,7 +570,6 @@ namespace SelectionTracking
                         LastUnsuccessfulSelection = OngoingSelection;
                         UnsuccessfulSelections.Add(OngoingSelection);
                         SelectionErrorHandling(termErrors);
-
                         //For EventCodes:
                         FixationOnEventCodeSent = false; //reset fixation
                     }

--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_Def_Namespace.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/USE_Def_Namespace.cs
@@ -136,6 +136,12 @@ namespace USE_Def_Namespace
         /// </summary>
         public string SelectionType = "mouse";
 
+
+        /// <summary>
+        /// Whether or not to run the eyetracker with the mosue position assigned as gaze input
+        /// </summary>
+        public bool SpoofGazeWithMouse;
+        
         /// <summary>
         /// Details of the monitor being used.
         /// </summary>
@@ -374,7 +380,6 @@ namespace USE_Def_Namespace
         /// Whether or not to run a stimulation
         /// </summary>
         public bool RunSimulation;
-
 
         /// <summary>
         /// Size of the circle for shotgun raycasting in DVA. Default is 1.25f.

--- a/USE_CORE/Assets/_USE_Tasks/FlexLearning/FlexLearning_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/FlexLearning/FlexLearning_TrialLevel.cs
@@ -194,7 +194,8 @@ public class FlexLearning_TrialLevel : ControlLevel_Trial_Template
             TokenFBController.SetUpdateTime(tokenUpdateDuration.value);
             TokenFBController.SetFlashingTime(tokenFlashingDuration.value);
 
-            ShotgunHandler.ClearSelections();
+            if (ShotgunHandler.AllSelections.Count > 0)
+                ShotgunHandler.ClearSelections();
             ShotgunHandler.MinDuration = minObjectTouchDuration.value;
             ShotgunHandler.MaxDuration = maxObjectTouchDuration.value;
         });

--- a/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibrationController.cs
+++ b/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibrationController.cs
@@ -121,23 +121,26 @@ public class GazeCalibrationController : MonoBehaviour
             
         }
 
-        if (transition.Equals("GazeCalibrationToSession"))
-            Session.GazeData.folderPath = path;
-        else
-            Session.GazeData.folderPath = path + Path.DirectorySeparatorChar + "GazeData";
+        if(!Session.SessionDef.SpoofGazeWithMouse){
+            if (transition.Equals("GazeCalibrationToSession"))
+                Session.GazeData.folderPath = path;
+            else
+                Session.GazeData.folderPath = path + Path.DirectorySeparatorChar + "GazeData";
 
-        if (transition.Equals("GazeCalibrationToTask"))
-            Session.TrialLevel.PathReassignmentComplete = true;
+            if (transition.Equals("GazeCalibrationToTask"))
+                Session.TrialLevel.PathReassignmentComplete = true;
 
-        if (transition.Equals("SessionToGazeCalibration"))
-        {
-            if (Session.SessionDef.SerialPortActive)
+            if (transition.Equals("SessionToGazeCalibration"))
             {
-                StartCoroutine(Session.SerialSentData.CreateFile());
-                StartCoroutine(Session.SerialRecvData.CreateFile());
+                if (Session.SessionDef.SerialPortActive)
+                {
+                    StartCoroutine(Session.SerialSentData.CreateFile());
+                    StartCoroutine(Session.SerialRecvData.CreateFile());
+                }
+                StartCoroutine(Session.GazeData.CreateFile());
             }
-            StartCoroutine(Session.GazeData.CreateFile());
         }
+
         if ( transition.Equals("TaskToGazeCalibration"))
         {
             if (Session.SessionDef.SerialPortActive)
@@ -145,6 +148,8 @@ public class GazeCalibrationController : MonoBehaviour
                 Session.SerialSentData.CreateNewTrialIndexedFile(GazeCalibrationTrialLevel.TrialCount_InTask + 1, Session.FilePrefix);
                 Session.SerialRecvData.CreateNewTrialIndexedFile(GazeCalibrationTrialLevel.TrialCount_InTask + 1, Session.FilePrefix);
             }
+
+            if(!Session.SessionDef.SpoofGazeWithMouse)
             Session.GazeData.CreateNewTrialIndexedFile(GazeCalibrationTrialLevel.TrialCount_InTask + 1, Session.FilePrefix);
         }
 
@@ -166,16 +171,16 @@ public class GazeCalibrationController : MonoBehaviour
                 break;
             case "SessionToGazeCalibration":
                 sessionGazeCalibrationFolderPath = Session.SessionDataPath + Path.DirectorySeparatorChar + "GazeCalibration" + Path.DirectorySeparatorChar + "TaskSelectionData";
-                serialRecvDataFileName = Session.SerialRecvData.fileName;
-                serialSentDataFileName = Session.SerialSentData.fileName;
-                gazeDataFileName = Session.GazeData.fileName;
+                serialRecvDataFileName = Session.SerialRecvData?.fileName;
+                serialSentDataFileName = Session.SerialSentData?.fileName;
+                gazeDataFileName = Session.GazeData?.fileName;
                 StartCoroutine(WriteSerialAndGazeDataAndReassignPath(sessionGazeCalibrationFolderPath, transition));
-                Debug.Log("**WRITING SESSION SERIAL AND GAZE DATA TO : " + Session.SerialRecvData.folderPath + " AND CHANGING PATH TO " + sessionGazeCalibrationFolderPath);
+                Debug.Log("**WRITING SESSION SERIAL AND GAZE DATA TO : " + Session.SerialRecvData?.folderPath + " AND CHANGING PATH TO " + sessionGazeCalibrationFolderPath);
                 break;
             case "GazeCalibrationToSession":
                 sessionFolderPath = Session.TaskSelectionDataPath;
                 StartCoroutine(WriteSerialAndGazeDataAndReassignPath(sessionFolderPath, transition));
-                Debug.Log("**WRITING GAZE CALIBRATION SERIAL AND GAZE DATA TO : " + Session.SerialRecvData.folderPath + " AND CHANGING PATH TO " + sessionFolderPath);
+                Debug.Log("**WRITING GAZE CALIBRATION SERIAL AND GAZE DATA TO : " + Session.SerialRecvData?.folderPath + " AND CHANGING PATH TO " + sessionFolderPath);
                 break;
             default:
                 Debug.LogWarning("INVALID TRANSITION TYPE BETWEEN DATA PATHS.");

--- a/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_Namespace.cs
+++ b/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_Namespace.cs
@@ -33,6 +33,7 @@ namespace GazeCalibration_Namespace
 {
     public class GazeCalibration_TaskDef : TaskDef
     {
+        public string RewardStructure;
     }
 
     public class GazeCalibration_BlockDef : BlockDef
@@ -40,7 +41,6 @@ namespace GazeCalibration_Namespace
         //Already-existing fields (inherited from BlockDef)
         //public int BlockCount;
         //public TrialDef[] TrialDefs;
-        public bool SpoofGazeWithMouse;
         public float[] CalibPointsInset;
         public float MaxCircleScale;
         public float MinCircleScale;
@@ -54,7 +54,6 @@ namespace GazeCalibration_Namespace
             GazeCalibration_TrialDef td = new GazeCalibration_TrialDef();
             td.NumPulses = NumPulses;
             td.PulseSize = PulseSize;
-            td.SpoofGazeWithMouse = SpoofGazeWithMouse;
             td.CalibPointsInset = CalibPointsInset;
             td.MaxCircleScale = MaxCircleScale;
             td.MinCircleScale = MinCircleScale;
@@ -71,7 +70,6 @@ namespace GazeCalibration_Namespace
         //public TrialStims TrialStims;
        // public int BlockID;
        // public int NumTrials;
-        public bool SpoofGazeWithMouse;
         public float[] CalibPointsInset = new float[] {0.15f, 0.15f};
         public float MaxCircleScale = 0.075f;
         public float MinCircleScale = 0.015f;
@@ -80,35 +78,7 @@ namespace GazeCalibration_Namespace
 
     public class GazeCalibration_StimDef : StimDef
     {
-        //Already-existing fields (inherited from Stim  Def)
-        //public Dictionary<string, StimGroup> StimGroups; //stimulus type field (e.g. sample/target/irrelevant/etc)
-        //public string StimName;
-        //public string StimPath;
-        //public string PrefabPath;
-        //public string ExternalFilePath;
-        //public string StimFolderPath;
-        //public string StimExtension;
-        //public int StimCode; //optional, for analysis purposes
-        //public string StimID;
-        //public int[] StimDimVals; //only if this is parametrically-defined stim
-        //[System.NonSerialized] //public GameObject StimGameObject; //not in config, generated at runtime
-        //public Vector3 StimLocation; //to be passed in explicitly if trial doesn't include location method
-        //public Vector3 StimRotation; //to be passed in explicitly if trial doesn't include location method
-        //public Vector2 StimScreenLocation; //screen position calculated during trial
-        //public float? StimScale;
-        //public bool StimLocationSet;
-        //public bool StimRotationSet;
-        //public float StimTrialPositiveFbProb; //set to -1 if stim is irrelevant
-        //public float StimTrialRewardMag; //set to -1 if stim is irrelevant
-        //public TokenReward[] TokenRewards;
-        //public int[] BaseTokenGain;
-        //public int[] BaseTokenLoss;
-        //public int TimesUsedInBlock;
-        //public bool IsRelevant;
-        //public bool TriggersSonication;
-        //public State SetActiveOnInitialization;
-        //public State SetInactiveOnTermination;
-    
+
     }
 
 }

--- a/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_TrialLevel.cs
@@ -181,7 +181,7 @@ public class GazeCalibration_TrialLevel : ControlLevel_Trial_Template
             SelectionHandler = Session.SelectionTracker.SetupSelectionHandler("trial", "MouseHover", Session.MouseTracker, Init, ITI);
         else
             SelectionHandler = Session.SelectionTracker.SetupSelectionHandler("trial", "GazeSelection", Session.GazeTracker, Init, ITI);
-        
+
 
         Init.AddUpdateMethod(() =>
         {


### PR DESCRIPTION
- Added SpoofGazeWithMouse throughout the hiearchical state scripts to allow the state machine to function without an active eyetracker
- Added configurable reward distribution for Gaze Calibration task
- checked for concerns of "cumulative gaze," but added MaxPixelDisplacement of 70 (~2 DVA) to terminate the selection if the gaze deviates that distance during the selection period (MinTouchDuration)