### PR TITLE
Remove max pixel displacement from gaze selection handler

### DIFF
--- a/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
+++ b/USE_CORE/Assets/_Scripts/M_USE/M_USE Modules/InputHandling/SelectionTracking.cs
@@ -172,7 +172,7 @@ namespace SelectionTracking
 
             gazeSelection.TerminationErrorTriggers.Add("DurationTooShort", gazeSelection.DefaultConditions("DurationTooShort"));
             gazeSelection.CurrentInputLocation = () => InputBroker.gazePosition;
-            gazeSelection.MaxPixelDisplacement = 70;
+            // gazeSelection.MaxPixelDisplacement = 70;
             gazeSelection.MinDuration = 0.7f;
             DefaultSelectionHandlers.Add("GazeSelection", gazeSelection);
 


### PR DESCRIPTION
- should resolve the issue with beeping from jitter in the eye-tracker positioning (originally added to resolve cumulative gaze issue)