### PR TITLE
NT_GazeLogicFix

### DIFF
--- a/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_TrialLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/GazeCalibration/GazeCalibration_TrialLevel.cs
@@ -330,6 +330,12 @@ public class GazeCalibration_TrialLevel : ControlLevel_Trial_Template
             if (CalibrationResult == null)
                 Debug.LogError("CALIBRATION RESULT IS NULL AFTER COMPUTING AND APPLYING");
         });
+        ApplyCalibration.SpecifyTermination(() => CalibrationResult != null, Fixate, () =>
+        {
+            calibNum = 0;
+            OnlyConfirming = true;
+        });
+
         ApplyCalibration.SpecifyTermination(() => CalibrationResult != null, ConfirmResults);
 
 


### PR DESCRIPTION
fixed the state logic to go back to fixate after initial calibration.