### PR TITLE
NT_WWW_AllowStimulationDebug

### DIFF
--- a/USE_CORE/Assets/_USE_Tasks/WhatWhenWhere/WhatWhenWhere_TaskLevel.cs
+++ b/USE_CORE/Assets/_USE_Tasks/WhatWhenWhere/WhatWhenWhere_TaskLevel.cs
@@ -110,8 +110,6 @@ public class WhatWhenWhere_TaskLevel : ControlLevel_Task_Template
                 BlockStimulationCode = currentBlockDef.StimulationConditionCodes[indexNum];
                 wwwTL.TrialStimulationCode = BlockStimulationCode;
             }
-            else
-                Debug.LogWarning("Allow Stimulation is set to true, but the StimulationConditionCodes are empty");
             
 
         });


### PR DESCRIPTION
removed the incorrect denbug log from WWW for when theres no stimulation.